### PR TITLE
Allow arbitrary inline markdown syntax

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { MarkdownPostProcessor, Plugin } from 'obsidian'
+import { Component, MarkdownPostProcessor, MarkdownRenderer, Plugin } from 'obsidian'
 
 const filenamePlaceholder: string = '%'
 const filenameExtensionPlaceholder: string = '%.%'
@@ -6,9 +6,9 @@ const filenameExtensionPlaceholder: string = '%.%'
 export default class ImageCaptions extends Plugin {
   observer: MutationObserver
 
-  async onload () {
+  async onload() {
     this.registerMarkdownPostProcessor(
-      externalImageProcessor()
+      externalImageProcessor(this)
     )
 
     this.observer = new MutationObserver((mutations: MutationRecord[]) => {
@@ -17,7 +17,7 @@ export default class ImageCaptions extends Plugin {
           (<Element>rec.target)
             // Search for all .image-embed nodes. Could be <div> or <span>
             .querySelectorAll('.image-embed')
-            .forEach(imageEmbedContainer => {
+            .forEach(async imageEmbedContainer => {
               const img = imageEmbedContainer.querySelector('img')
               const width = imageEmbedContainer.getAttribute('width') || ''
               const captionText = getCaptionText(imageEmbedContainer)
@@ -29,7 +29,8 @@ export default class ImageCaptions extends Plugin {
                 // Check if the text needs to be updated
                 if (figCaption && captionText) {
                   // Update the text in the existing element
-                  figCaption.innerText = captionText
+                  const children = await renderMarkdown(captionText, "", this) ?? [captionText];
+                  figCaption.replaceChildren(...children);
                 } else if (!captionText) {
                   // The alt-text has been removed, so remove the custom <figure> element
                   // and set it back to how it was originally with just the plain <img> element
@@ -38,7 +39,7 @@ export default class ImageCaptions extends Plugin {
                 }
               } else {
                 if (captionText && captionText !== imageEmbedContainer.getAttribute('src')) {
-                  insertFigureWithCaption(img, imageEmbedContainer, captionText)
+                  insertFigureWithCaption(img, imageEmbedContainer, captionText, "", this)
                 }
               }
               if (width) {
@@ -55,8 +56,8 @@ export default class ImageCaptions extends Plugin {
     this.observer.observe(document.body, { subtree: true, childList: true })
   }
 
-  onunload () {
-    this.observer.disconnect()
+  onunload() {
+    // this.observer.disconnect()
   }
 }
 
@@ -68,7 +69,7 @@ export default class ImageCaptions extends Plugin {
  *
  * @param img
  */
-function getCaptionText (img: HTMLElement | Element) {
+function getCaptionText(img: HTMLElement | Element) {
   let captionText = img.getAttribute('alt') || ''
   const src = img.getAttribute('src') || ''
   if (captionText === src) {
@@ -90,6 +91,9 @@ function getCaptionText (img: HTMLElement | Element) {
     // Remove the escaping to allow the placeholder to be used verbatim
     captionText = filenamePlaceholder
   }
+  captionText = captionText.replace(/\<\<(.*?)\>\>/g, (match, linktext) => {
+    return '[[' + linktext + ']]'
+  })
   return captionText
 }
 
@@ -97,14 +101,14 @@ function getCaptionText (img: HTMLElement | Element) {
  * External images can be processed with a Markdown Post Processor, but only
  * in Reading View.
  */
-function externalImageProcessor (): MarkdownPostProcessor {
-  return (el) => {
+function externalImageProcessor(plugin: ImageCaptions): MarkdownPostProcessor {
+  return (el, ctx) => {
     el.findAll('img:not(.emoji)')
       .forEach(img => {
         const captionText = getCaptionText(img)
         const parent = img.parentElement
         if (parent && parent?.nodeName !== 'FIGURE' && captionText && captionText !== img.getAttribute('src')) {
-          insertFigureWithCaption(img, parent, captionText)
+          insertFigureWithCaption(img, parent, captionText, ctx.sourcePath, plugin)
         }
       })
   }
@@ -122,12 +126,30 @@ function externalImageProcessor (): MarkdownPostProcessor {
  * @param outerEl
  * @param captionText
  */
-function insertFigureWithCaption (imageEl: HTMLElement, outerEl: HTMLElement | Element, captionText: string) {
+async function insertFigureWithCaption(imageEl: HTMLElement, outerEl: HTMLElement | Element, captionText: string, sourcePath: string, plugin: ImageCaptions) {
   const figure = outerEl.createEl('figure')
   figure.addClass('image-captions-figure')
   figure.appendChild(imageEl)
+  const children = await renderMarkdown(captionText, sourcePath, plugin) ?? [captionText];
   figure.createEl('figcaption', {
-    text: captionText,
     cls: 'image-captions-caption'
-  })
+  }).replaceChildren(...children);
+}
+
+/**
+ * Easy-to-use version of MarkdownRenderer.renderMarkdown. Returns only the child nodes, rather than a container block.
+ * @param markdown 
+ * @param sourcePath 
+ * @param component - Typically you can just pass the plugin instance, but Liam from the Obsidian team says 
+ *   it's not a good practice (https://github.com/obsidianmd/obsidian-releases/pull/2263#issuecomment-1711864829). 
+ *   I'm currently struggling to find a proper way to do it.
+ */
+export async function renderMarkdown(markdown: string, sourcePath: string, component: Component): Promise<NodeList | undefined> {
+  const el = createDiv();
+  await MarkdownRenderer.renderMarkdown(markdown, el, sourcePath, component);
+  for (const child of el.children) {
+    if (child.tagName == "P") {
+      return child.childNodes;
+    }
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,7 +57,7 @@ export default class ImageCaptions extends Plugin {
   }
 
   onunload() {
-    // this.observer.disconnect()
+    this.observer.disconnect()
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
       "DOM",
       "ES5",
       "ES6",
-      "ES7"
+      "ES7",
+      "DOM.Iterable"
     ]
   },
   "include": [


### PR DESCRIPTION
Hi, thank you for making this!

I want to propose enabling arbitrary inline markdown syntax in caption text.
(Related issue: #12)

I did it by passing `captionText` to `MarkdownRenderer.renderMarkdown`.

The current approach has at least two limitations:
- `renderMarkdown` requires `sourcePath` to correctly process links, but I'm not aware how we can get `sourcePath` in the callback function passed to `MutationObserver`. This can affect how other link-related plugins (e.g. [MathLinks](https://github.com/zhaoshenzhai/obsidian-mathlinks), [Strange New Worlds](https://github.com/TfTHacker/obsidian42-strange-new-worlds)) work. Maybe we can address it by using `MarkdownRenderChild`, and trigger reloading every time a mutation occurs (but I've had no luck so far)
- As for internal images, it cannot deal with caption text that contains internal links like `![[Pasted image 20230918180409.png|Compatible with [[MathLinks]]]]`. So I had to make up a original notation `<< >>` to avoid this: `![[Pasted image 20230918180409.png|Compatible with <<MathLinks>>]]`. Obviously this isn't cool.

(Also, I'm currently passing the plugin instance to `renderMarkdown`'s last parameter `component`, but it doesn't seem to be a good practice (https://github.com/obsidianmd/obsidian-releases/pull/2263#issuecomment-1711864829).
I haven't found a proper way to do it yet.)

How do you like it?

Example: 

<img width="1552" alt="image" src="https://github.com/alangrainger/obsidian-image-captions/assets/72342591/2529068f-933f-4c82-9b17-de3ab99e1a10">
<img width="1552" alt="image" src="https://github.com/alangrainger/obsidian-image-captions/assets/72342591/4a73c69c-fd8c-45c9-81c4-4b300a51b6f4">



Source:

```
## External link example

`![$\mathcal{A}$rb*itrary* **Inline** [[Markdown]] ==Syntax==! Compatible with [[MathLinks]]](https://github.com/RyotaUshio/obsidian-image-captions/raw/main/example.png)`

In this case, it's compatible with MathLinks because I CAN pass `sourcePath` to `renderMarkdown` in `externalImageProcessor`.

![$\mathcal{A}$rb*itrary* **Inline** [[Markdown]] ==Syntax==! Compatible with [[MathLinks]]](https://github.com/RyotaUshio/obsidian-image-captions/raw/main/example.png)


## Internal link example

`![[Pasted image 20230918180409.png|Compatible with <<MathLinks>>]]`

In this case, it's not compatible with MathLinks because I can't pass `sourcePath` to `renderMarkdown` in `MutationObserver`.

![[Pasted image 20230918180409.png|Incompatible with <<MathLinks>>]]
```

