### PR TITLE
Add caption support for video embeds

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,9 +21,9 @@ export default class ImageCaptions extends Plugin {
         if (rec.type === 'childList') {
           (<Element>rec.target)
             // Search for all .image-embed nodes. Could be <div> or <span>
-            .querySelectorAll('.image-embed')
+            .querySelectorAll('.image-embed, .video-embed')
             .forEach(async imageEmbedContainer => {
-              const img = imageEmbedContainer.querySelector('img')
+              const img = imageEmbedContainer.querySelector('img, video')
               const width = imageEmbedContainer.getAttribute('width') || ''
               const captionText = this.getCaptionText(imageEmbedContainer)
               if (!img) return
@@ -118,7 +118,7 @@ export default class ImageCaptions extends Plugin {
    */
   externalImageProcessor (): MarkdownPostProcessor {
     return (el, ctx) => {
-      el.findAll('img:not(.emoji)')
+      el.findAll('img:not(.emoji), video')
         .forEach(async img => {
           const captionText = this.getCaptionText(img)
           const parent = img.parentElement


### PR DESCRIPTION
Hi there!

Thanks for the great plugin! I gave it a try and the one thing that was missing for me was that it did not caption videos. I hoped/expected this would just work, as image embeds and video embeds are otherwise extremely similar.

So, this PR just adds caption support for videos. As you can see the changes are really minor, so it should not cause any issues whatsoever.

I left all the variable names as `imgFoo` instead of changing them to `mediaFoo` because primarily this is an image captioning plugin, but I think this small extra functionality could not hurt.

Hope this can be included. Thanks!

![20241112-212004_Screenshot_Obsidian](https://github.com/user-attachments/assets/817d33ad-64ce-432a-b4d5-fe4f797219ea)