### PR TITLE
#58 restore drag-and-drop resize as designed

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,10 @@ export default class ImageCaptions extends Plugin {
                 }
               } else {
                 if (captionText && captionText !== imageEmbedContainer.getAttribute('src')) {
-                  await this.insertFigureWithCaption(img as HTMLElement, imageEmbedContainer, captionText, '')
+                  const parent = img.parentElement
+                  await this.insertFigureWithCaption(
+                    img as HTMLElement, parent ? parent : imageEmbedContainer, captionText, ''
+                  )
                 }
               }
               if (width) {


### PR DESCRIPTION
Change the way the dom is edited to restore the drag-and-drop resize as designed in vanilla Obsidian.

It's a "naive" fix because I don't practical Typescript so much, but it seems to work correctly :)

Fix #58 