### PR TITLE
#45 option to choose background colors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -150,12 +150,15 @@ export default class ImageCaptions extends Plugin {
    * @param sourcePath
    */
   async insertFigureWithCaption (imageEl: HTMLElement, outerEl: HTMLElement | Element, captionText: string, sourcePath: string) {
-    const figure = outerEl.createEl('figure')
+    const figure = outerEl.createEl('figure', {
+      attr: { "style": "background:" + this.settings.captionImgColor}
+    })
     figure.addClass('image-captions-figure')
     figure.appendChild(imageEl)
     const children = await renderMarkdown(captionText, sourcePath, this) ?? [captionText]
     figure.createEl('figcaption', {
-      cls: 'image-captions-caption'
+      cls: 'image-captions-caption',
+      attr: { "style": "background:" + this.settings.captionBckColor }
     }).replaceChildren(...children)
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,10 +3,14 @@ import ImageCaptions from './main'
 
 export interface CaptionSettings {
   captionRegex: string;
+  captionImgColor: string;
+  captionBckColor: string;
 }
 
 export const DEFAULT_SETTINGS: CaptionSettings = {
-  captionRegex: ''
+  captionRegex: '',
+  captionBckColor: '--color-base-30',
+  captionImgColor: '--color-base-30',
 }
 
 export class CaptionSettingTab extends PluginSettingTab {
@@ -38,6 +42,41 @@ export class CaptionSettingTab extends PluginSettingTab {
         .onChange(async value => {
           this.plugin.settings.captionRegex = value
           await this.plugin.saveSettings()
+        }))
+
+    const colorHelper = 'Could be an hexadecimal value, a css value (e.g. "--color-base-30") or a string value (e.g. "yellow"'
+    new Setting(containerEl)
+      .setName('Caption background color')
+      .setDesc('Choose the color of the backgroud of the caption.' + colorHelper)
+      .addText(text => text
+        .setValue(this.plugin.settings.captionBckColor)
+        .onChange(async value => {
+          this.plugin.settings.captionBckColor = value
+          await this.plugin.saveSettings()
+        }))
+      .addButton(btn => btn
+        .setIcon("rotate-ccw")
+        .onClick(async value => {
+            this.plugin.settings.captionBckColor = DEFAULT_SETTINGS.captionBckColor
+            await this.plugin.saveSettings()
+            this.display()
+        }))
+
+    new Setting(containerEl)
+      .setName('Image background color')
+      .setDesc('Choose the color of the image background' + colorHelper)
+      .addText(text => text
+        .setValue(this.plugin.settings.captionImgColor)
+        .onChange(async value => {
+          this.plugin.settings.captionImgColor = value
+          await this.plugin.saveSettings()
+        }))
+      .addButton(btn => btn
+        .setIcon("rotate-ccw")
+        .onClick(async value => {
+            this.plugin.settings.captionImgColor = DEFAULT_SETTINGS.captionImgColor
+            await this.plugin.saveSettings()
+            this.display()
         }))
   }
 }


### PR DESCRIPTION
To make the extension more self-supporting and answering #45,
This PR add two options to set backgroud colors for image and for caption.

I think there is a lot of way to do it better, but maybe it could be a first step.